### PR TITLE
feat: claim endpoints and fixes

### DIFF
--- a/server/src/database/entities/migration.entity.ts
+++ b/server/src/database/entities/migration.entity.ts
@@ -54,7 +54,7 @@ export class Migration {
   @Column({ nullable: true, default: null })
   manifestHash: string;
 
-  @Column({ nullable: true, length: 255 })
+  @Column({ nullable: true, length: 8192 })
   error?: string;
 
   intoDto(): MigrationDto {

--- a/server/src/database/entities/migration.entity.ts
+++ b/server/src/database/entities/migration.entity.ts
@@ -57,9 +57,6 @@ export class Migration {
   @Column({ nullable: true, length: 255 })
   error?: string;
 
-  @Column({ nullable: true, default: null })
-  session?: string;
-
   intoDto(): MigrationDto {
     return {
       status: this.status,
@@ -70,7 +67,6 @@ export class Migration {
       manifestDatetime: this.manifestDatetime,
       manifestHash: this.manifestHash,
       error: this.error,
-      session: this.session,
     };
   }
 
@@ -90,7 +86,6 @@ export class Migration {
       manifestDatetime: this.manifestDatetime,
       manifestHash: this.manifestHash,
       error: this.error,
-      session: this.session,
     }
   }
 

--- a/server/src/dto/migration.dto.ts
+++ b/server/src/dto/migration.dto.ts
@@ -40,9 +40,6 @@ export class MigrationDto {
   @ApiProperty({ description: "Errors encountered during the migration"})
   error: string;
 
-  @ApiProperty({ description: "Migration claim session" })
-  session: string;
-
 }
 
 export class MigrationDetailsDto {
@@ -112,9 +109,6 @@ export class UpdateMigrationDto {
 
   @ApiProperty({ description: "Errors encountered during the migration"})
   error: string;
-
-  @ApiProperty({ description: "Migration claim session" })
-  session: string;
 
 }
 

--- a/server/src/neighborhoods/migrations/migrations.controller.ts
+++ b/server/src/neighborhoods/migrations/migrations.controller.ts
@@ -102,8 +102,9 @@ export class MigrationsController {
   async claimOne(
     @Param("nid", ParseIntPipe) nid: number,
     @Param("uuid") uuid: string,
+    @Query("force") force?: boolean,
   ): Promise<MigrationDto> {
-    const migration = await this.migrations.claimOneByUuid(nid, uuid);
+    const migration = await this.migrations.claimOneByUuid(nid, uuid, force);
     if (!migration) {
       throw new NotFoundException(`Could not claim migration with UUID ${uuid}`);
     }

--- a/server/src/neighborhoods/migrations/migrations.controller.ts
+++ b/server/src/neighborhoods/migrations/migrations.controller.ts
@@ -103,7 +103,11 @@ export class MigrationsController {
     @Param("nid", ParseIntPipe) nid: number,
     @Param("uuid") uuid: string,
   ): Promise<MigrationDto> {
-    return await this.migrations.claimOneByUuid(nid, uuid);
+    const migration = await this.migrations.claimOneByUuid(nid, uuid);
+    if (!migration) {
+      throw new NotFoundException(`Could not claim migration with UUID ${uuid}`);
+    }
+    return migration
   }
 
   @Put(":uuid") 
@@ -121,7 +125,7 @@ export class MigrationsController {
   ): Promise<UpdateMigrationDto> {
     const migration = await this.migrations.updateOneByUuid(nid, uuid, updateMigrationDto);
     if (!migration) {
-      throw new NotFoundException();
+      throw new NotFoundException(`Could not update migration with UUID ${uuid}`);
     }
 
     return migration;

--- a/server/src/neighborhoods/migrations/migrations.controller.ts
+++ b/server/src/neighborhoods/migrations/migrations.controller.ts
@@ -77,6 +77,20 @@ export class MigrationsController {
     };
   }
 
+  @Put('claim')
+  @ApiOperation({
+    description: "Claim migrations for a neighborhood",
+  })
+  @ApiOkResponse({
+    type: MigrationDto,
+    isArray: true,
+  })
+  async claimMany(
+    @Param("nid", ParseIntPipe) nid: number,
+  ): Promise<MigrationDto[]> {
+    return await this.migrations.claimMany(nid);
+  }
+
   @Put(":uuid") 
   @ApiOperation({
     description: "Update the status of a migration",
@@ -97,6 +111,4 @@ export class MigrationsController {
 
     return migration;
   }
-
-
 }

--- a/server/src/neighborhoods/migrations/migrations.controller.ts
+++ b/server/src/neighborhoods/migrations/migrations.controller.ts
@@ -91,6 +91,21 @@ export class MigrationsController {
     return await this.migrations.claimMany(nid);
   }
 
+  @Put('claim/:uuid')
+  @ApiOperation({
+    description: "Claim a single migration for a neighborhood",
+  })
+  @ApiOkResponse({
+    type: MigrationDto,
+    isArray: false,
+  })
+  async claimOne(
+    @Param("nid", ParseIntPipe) nid: number,
+    @Param("uuid") uuid: string,
+  ): Promise<MigrationDto> {
+    return await this.migrations.claimOneByUuid(nid, uuid);
+  }
+
   @Put(":uuid") 
   @ApiOperation({
     description: "Update the status of a migration",

--- a/server/src/neighborhoods/migrations/migrations.controller.ts
+++ b/server/src/neighborhoods/migrations/migrations.controller.ts
@@ -87,8 +87,10 @@ export class MigrationsController {
   })
   async claimMany(
     @Param("nid", ParseIntPipe) nid: number,
+    @Query("limit", new DefaultValuePipe(10), ParseIntPipe) limit: number = 10,
   ): Promise<MigrationDto[]> {
-    return await this.migrations.claimMany(nid);
+    limit = limit > 100 ? 100 : limit;
+    return await this.migrations.claimMany(nid, limit);
   }
 
   @Put('claim/:uuid')

--- a/server/src/neighborhoods/migrations/migrations.service.ts
+++ b/server/src/neighborhoods/migrations/migrations.service.ts
@@ -72,6 +72,7 @@ export class MigrationsService {
 
   public async claimMany(
     neighborhoodId: number,
+    limit: number,
   ): Promise<MigrationDto[]> {
     const queryRunner = this.datasource.createQueryRunner();
     let updatedMigrations = [];
@@ -83,7 +84,7 @@ export class MigrationsService {
         .createQueryBuilder()
         .setLock('pessimistic_write')
         .setOnLocked('skip_locked')
-        .limit(10) // Limit to 10 rows
+        .limit(limit) // Limit the number of rows to claim
         .select()
         .from(Migration, 'm')
         .where('m.status = 1') // Created

--- a/server/src/neighborhoods/migrations/migrations.service.ts
+++ b/server/src/neighborhoods/migrations/migrations.service.ts
@@ -154,7 +154,7 @@ export class MigrationsService {
       }
 
       // Update the locked row
-      await queryRunner.manager.update(Migration, { uuid: uuid }, { status: 2 }); // Claimed
+      await queryRunner.manager.update(Migration, { uuid: uuid }, { status: 2, error: undefined }); // Claimed
 
       // Commit the transaction, release the lock
       await queryRunner.commitTransaction();

--- a/server/src/neighborhoods/migrations/migrations.service.ts
+++ b/server/src/neighborhoods/migrations/migrations.service.ts
@@ -85,7 +85,6 @@ export class MigrationsService {
       const lockedMigration = await queryRunner.manager
         .createQueryBuilder()
         .setLock('pessimistic_write')
-        .setOnLocked("nowait")
         .select()
         .from(Migration, 'm')
         .where('uuid = :uuid', { uuid })
@@ -94,6 +93,8 @@ export class MigrationsService {
         .innerJoin(Block, 'b', 'b.id = t.blockId AND b.neighborhoodId = :neighborhoodId', { neighborhoodId: neighborhoodId })
         .execute()
 
+      // this.logger.debug(`lockedMigration: ${JSON.stringify(lockedMigration)}`);
+
       // Verify lock was obtained
       const affectedRows = lockedMigration.length ?? 0;
       if (affectedRows === 0) {
@@ -101,7 +102,7 @@ export class MigrationsService {
       }
   
       // Update the locked row
-      this.logger.debug(`Updating locked migration row with UUID: ${uuid}`)
+      this.logger.debug("Updating locked migration row with UUID ${uuid}.")
       await queryRunner.manager.update(Migration, { uuid: uuid }, updateMigrationDto);
   
       // Commit the transaction, release the lock

--- a/server/src/neighborhoods/migrations/migrations.service.ts
+++ b/server/src/neighborhoods/migrations/migrations.service.ts
@@ -144,7 +144,7 @@ export class MigrationsService {
       // Verify lock was obtained
       const affectedRows = lockedMigration.length ?? 0;
       if (affectedRows === 0) {
-        throw new Error(`Could not acquire lock for migration with UUID ${uuid}`);
+        return null
       }
 
       // Update the locked row
@@ -194,11 +194,10 @@ export class MigrationsService {
       // Verify lock was obtained
       const affectedRows = lockedMigration.length ?? 0;
       if (affectedRows === 0) {
-        throw new Error(`Could not acquire lock for migration with UUID: ${uuid}`);
+        return null
       }
 
       // Update the locked row
-      this.logger.debug("Updating locked migration row with UUID ${uuid}.")
       await queryRunner.manager.update(Migration, { uuid: uuid }, updateMigrationDto);
   
       // Commit the transaction, release the lock


### PR DESCRIPTION
This PR
- Reverts `nowait` and session column
- Bump the error column size
- Adds two new endpoints for work item claiming

The endpoints are
```
.../migrations/claim/        // Claim multiple work items
.../migrations/claim/{uuid}  // Claim a single work item from uuid
```
Claiming is performed in a single request versus multiple requests previously.

The `/claim/` endpoint supports the `limit` parameter allowing control over the number of items claimed in a single request. The default limit is 10 items. The maximum enforced by the server is 100.

The `/claim/{uuid}` endpoint supports the `force` parameter. When set to `true`, one is allowed to claim any item whatever the state.

Proper locking was tested using https://github.com/fmorency/migration-e2e.