### PR TITLE
feat: multisig support for migration

### DIFF
--- a/server/src/services/scheduler/migration-analyzer.service.ts
+++ b/server/src/services/scheduler/migration-analyzer.service.ts
@@ -72,6 +72,8 @@ export class MigrationAnalyzerService {
         .createQueryBuilder('td')
         .select(["td.id", "td.argument", "td.result"])
         .where("td.argument -> 'transaction' -> 'argument' ->> 'to' = :illegalAddress") // The migration destination address the illegal address (inner transaction)
+        .andWhere("td.argument -> 'transaction' ->> 'method' = 'ledger.send'") // The migration inner transaction is a ledger send
+        .andWhere("td.argument -> 'transaction' -> 'argument' ->> 'memo' ~* :uuidPattern") // The migration inner transaction has a memo that is a UUID
         .andWhere("td.argument ->> 'memo' ~* :uuidPattern") // The multisig submit transaction has a memo that is a UUID
         .andWhere("td.error IS NULL")
         .andWhere("td.method = 'account.multisigSubmitTransaction'")

--- a/server/src/services/scheduler/migration-analyzer.service.ts
+++ b/server/src/services/scheduler/migration-analyzer.service.ts
@@ -38,7 +38,7 @@ export class MigrationAnalyzerService {
       .where('m.transactionId = t.id');
 
       // Check for missing migrations for neighborhood
-      const query = await this.txDetailsRepository
+      const query = this.txDetailsRepository
         .createQueryBuilder('td')
         .select(["td.id", "td.argument", "t.id"])
         .where("td.argument ->> 'memo' ~* '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'")
@@ -52,6 +52,8 @@ export class MigrationAnalyzerService {
       query.setParameters(subQuery.getParameters());
 
       const results = await query.getMany();
+
+      this.logger.debug(`Missing migrations for neighborhood ${JSON.stringify(results)}`)
 
       return results;
     }

--- a/server/src/services/scheduler/migration-analyzer.service.ts
+++ b/server/src/services/scheduler/migration-analyzer.service.ts
@@ -55,7 +55,20 @@ export class MigrationAnalyzerService {
 
       this.logger.debug(`Missing migrations for neighborhood ${JSON.stringify(results)}`)
 
-      return results;
+      const q2 = this.txDetailsRepository
+        .createQueryBuilder('td')
+        .select(["td.id", "td.argument", "t.id"])
+        .where("td.method = 'account.multisigExecute'")
+        .andWhere("td.error IS NULL")
+
+      q2.setParameters(subQuery.getParameters());
+
+      const r2 = await q2.getMany();
+
+      this.logger.debug(`Missing migrations for neighborhood 2 ${JSON.stringify(r2)}`)
+
+
+    return results;
     }
 
     async analyzeMigration(

--- a/server/src/services/scheduler/migration-analyzer.service.ts
+++ b/server/src/services/scheduler/migration-analyzer.service.ts
@@ -42,7 +42,7 @@ export class MigrationAnalyzerService {
         .createQueryBuilder('td')
         .select(["td.id", "td.argument", "t.id"])
         .where("td.argument ->> 'to' = 'maiyg'") // The migration destination address is 'maiyg'
-        .where("td.argument ->> 'memo' ~* :uuidPattern") // The migration transaction has a memo that is a UUID
+        .andWhere("td.argument ->> 'memo' ~* :uuidPattern") // The migration transaction has a memo that is a UUID
         .andWhere("td.error IS NULL")
         .andWhere("td.method = 'ledger.send'")
         .innerJoinAndSelect('td.transaction', 't')
@@ -70,7 +70,7 @@ export class MigrationAnalyzerService {
         .createQueryBuilder('td')
         .select(["td.id", "td.argument", "td.result"])
         .where("td.argument ->> 'to' = 'maiyg'") // The migration destination address is 'maiyg'
-        .where("td.argument ->> 'memo' ~* :uuidPattern") // The multisig submit transaction has a memo that is a UUID
+        .andWhere("td.argument ->> 'memo' ~* :uuidPattern") // The multisig submit transaction has a memo that is a UUID
         .andWhere("td.error IS NULL")
         .andWhere("td.method = 'account.multisigSubmitTransaction'")
         .innerJoinAndSelect('td.transaction', 't')


### PR DESCRIPTION
This PR adds multisig support in the migration analyzer. 

The following criteria need to be met for the migration to be considered

- Multisig Submit transaction contains a `memo` with a `uuid` (and a destination address).
- Multisig Submit has a matching Multisig Execute transaction. The Multisig Token is used for matching
- The Multisig Submit inner transaction is of type `ledger.send` and contains a `memo` with a `uuid` (and a destination address)
- The Multisig Submit inner transaction `to` is the MANY illegal address

I also refactored the standard `ledger.send` migration to verify the `to` is the MANY illegal address.

Tested using https://github.com/fmorency/migration-e2e commit `1b9ca33afb209fa5907848a54a2d55b3c6a3e4aa`